### PR TITLE
Added the Hook test graphics to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Hook Status](http://ci.perseids.org/api/rest/v1.0/code/OpenGreekAndLatin/csel-dev/status.svg?branch=refs%2Fheads%2Fmaster)](http://ci.perseids.org/repo/OpenGreekAndLatin/csel-dev)
+[![Hook Coverage](http://ci.perseids.org/api/rest/v1.0/code/OpenGreekAndLatin/csel-dev/coverage.svg?branch=refs%2Fheads%2Fmaster)](http://ci.perseids.org/Hook/repo/OpenGreekAndLatin/csel-dev)
+[![Hook Texts](http://ci.perseids.org/api/rest/v1.0/code/OpenGreekAndLatin/csel-dev/cts.svg?branch=refs%2Fheads%2Fmaster)](http://ci.perseids.org/Hook/repo/OpenGreekAndLatin/csel-dev)
+
 csel-dev
 ========
 


### PR DESCRIPTION
This should allow the Hook test graphics to show up on the front page of the CSEL-dev repo