### PR TITLE
Ocr culus error

### DIFF
--- a/data/stoa0022/stoa048/stoa0022.stoa048.opp-lat1.xml
+++ b/data/stoa0022/stoa048/stoa0022.stoa048.opp-lat1.xml
@@ -3387,21 +3387,21 @@
           om. ji</hi> obreptione] obtrectatione <hi rend="italic">(sic) B</hi> 14 exoluit <lb/>
          <hi rend="italic">DEmlFml</hi> 17 menta <hi rend="italic">ftav</hi> 21 inquid <hi rend="italic">Bml</hi> 2\'4 sicut] uelut <hi rend="italic">BC</hi> abissus A </note>
         <lb n="30"/>
-        <pb n="62"/> misericordia ergo petenda de caelo estueritas dei ex prophetarum ora- <lb/>
+        <pb n="62"/> misericordia ergo petenda de caelo estueritas dei ex prophetarum oraculis colligenda, qui quasi nubes mysteria diuinae cognitionis obtexunt.<lb/>
        </p>
       </div>
 
       <div n="3" subtype="section" type="textpart">
-       <p> culis colligenda, qui quasi nubes mysteria diuinae cognitionis obtexunt. <lb/> posuit
-         <sic>emm</sic> tenebras deus latibulum suum, <sic>utprimo</sic> pluuiam <lb/> mysticae
+       <p> <lb/> posuit
+         <sic>enim</sic> tenebras deus latibulum suum, <sic>ut primo</sic> pluuiam <lb/> mysticae
         fertilitatis accipias et tunc infusus rore caelesti fulgorem <lb/> reseratae lucis agnoscas,
         ut possis dicere: ex plenitudine <lb n="5"/> eius accepimus. quis enim potest secreta dei
-        facile conprehendere, <lb/> cuius iustitia sicut montes dei uel, sicut <sic n="poss">Aqui</sic>- <lb/>
+        facile conprehendere, <lb/> cuius iustitia sicut montes dei uel, sicut <sic n="poss">Aquilas</sic> <lb/>
        </p>
       </div>
 
       <div n="4" subtype="section" type="textpart">
-       <p> las posuit, ut montes ua1idi, eo quod ualidae uirtutis <lb/> plena praecepta sint? unde
+       <p>  posuit, ut montes ua1idi, eo quod ualidae uirtutis <lb/> plena praecepta sint? unde
         et apostolus uidens esse sublimia audet <lb/> et dicit: o altitudo diuitiarum 
          sapientiae
          
@@ -8907,7 +8907,7 @@
          non est sanitas in <lb n="20"/> carne mea. incuruatus sum et humiliatus sum <lb/> nimis,
          rugiebam a gemitu cordis mei. et ante<lb/> te omne desiderium meum et gemitus meus non
          <lb/> est ab s conditus a te. cor meum conturbatum <lb/> est et deseruit me fortitudo mea,
-         et lumen o <sic>culorum</sic><lb n="25"/> meorum non est mecum</hi>. aduertimus igitur
+         et lumen oculorum<lb n="25"/> meorum non est mecum</hi>. aduertimus igitur
         laborem <lb/> animae maiorem esse quam carnis.</p>
       </div>
 
@@ -20993,11 +20993,10 @@
      </div>
      <div n="26" subtype="chapter" type="textpart">
       <div n="1" subtype="section" type="textpart">
-       <p><hi rend="italic">I <sic>ntr</sic>
-         <sic>oibit</sic> usque in progeniem patrum <lb/>
-         <sic>eiu</sic> s, u s que in s ae culum non uidebit lumen. <lb n="10"/> homo cum in honore
-         es s et non intellexit, comparatus <lb/> est iumentis quae sensum non habent <lb/> et
-         similis f actus est illis</hi>. ideo, inquit, iste in progeniem <lb/> patrum suorum
+       <p><hi rend="italic">Introibit usque in progeniem patrum <lb/>
+         eius, usque in saeculum non uidebit lumen. <lb n="10"/> homo cum in honore
+         esset non intellexit, comparatus <lb/> est iumentis quae sensum non habent <lb/> et
+         similis factus est illis</hi>. ideo, inquit, iste in progeniem <lb/> patrum suorum
         introibit. qui est pater impiorum, dominus declarauit <lb/> dicens: uos ex patre diabolo
         estis.</p>
       </div>

--- a/data/stoa0022/stoa051/stoa0022.stoa051.opp-lat1.xml
+++ b/data/stoa0022/stoa051/stoa0022.stoa051.opp-lat1.xml
@@ -15930,8 +15930,8 @@ dicationis saluos facere credentes.</p></div>
             namque succedentibus aliis haec quasi degenerantia respuuntur <lb/>
             et arenti infirma radice renouatis quibus sit sucus utilior <lb/>
             exuuntur. manent tamen aliqua. perrara nec decidunt, quibus <note type="margin"> K </note> <lb/>
-            hic prouentus adriserit, ut de medio duarum uirgarum claui <lb n="10"/>
-            culo breui erumpente promergant, quo geminis tecta praesidiis. <lb/>
+            hic prouentus adriserit, ut de medio duarum uirgarum clauiculo <lb n="10"/>
+             breui erumpente promergant, quo geminis tecta praesidiis. <lb/>
             tamquam naturae parentis gremio suci fotu plenioris inolescant. <lb/>
             ea clementioris aurae prouocata temperie et prolixioribus <lb/>
             adultiora.temporibus ubi siluestrem animum suci prioris exuerint. <lb/>

--- a/data/stoa0040/stoa003/stoa0040.stoa003.opp-lat4.xml
+++ b/data/stoa0040/stoa003/stoa0040.stoa003.opp-lat4.xml
@@ -19681,8 +19681,8 @@
           <p>Et ciuitatem, inquit, magnam Hierusalem nouam <lb/>
             uidi descendentem de caelo a Deo, aptatam, quasi <lb/>
             nouam nuptam ornatam marito suo. Et audiui uocem <lb/>
-            magnam de throno dicentem: Ecce taberna <lb n="10"/>
-            culum Dei cum hominibus, et habitabit cum eis. <lb/>
+            magnam de throno dicentem: Ecce tabernaculum <lb n="10"/>
+             Dei cum hominibus, et habitabit cum eis. <lb/>
             et erunt ipsi populus eius, et ipse Deus erit cum <lb/>
             eis. Et absterget omnem lacrimam ab oculis eorum: <lb/>
             et mors iam non erit neque luctus neque clamor. <lb/>

--- a/data/stoa0040/stoa033/stoa0040.stoa033.opp-lat1.xml
+++ b/data/stoa0040/stoa033/stoa0040.stoa033.opp-lat1.xml
@@ -2490,11 +2490,11 @@
             ubi a fide catholica naufragauit, nisi refecerit paenitendo quod <lb/>
             fregit. illum ego turbinem atque illa saxa deuitans nauem illis committere <lb/>
             nolui et de hac re ita scripsi, ut rationem potius cunctationis <lb n="25"/>
-            meae quam temeritatem praesumptionis ostenderem. quod opus-
-</p>
-          <p>19 Vine. Victor; cf. pag. 309,9 25 cf. Aug. De libero arbitrio III 59—G2 <lb/>
+            meae quam temeritatem praesumptionis ostenderem. quod opusculum
+            
+          <note type="footnote">19 Vine. Victor; cf. pag. 309,9 25 cf. Aug. De libero arbitrio III 59—G2 <lb/>
             (XXXII 129G M). De pecc. meritis II 36, 56. Epist. 166 (CSEL XXXXIV <lb/>
-            545). Epist. 190 (CSEL LVII 137)
+            545). Epist. 190 (CSEL LVII 137)</note>
 
 <note type="footnote"> 1 religare <hi rend="italic">BCDEFG</hi> consortia <hi rend="italic">A</hi> 2 hinc cepit <hi rend="italic">E</hi> 3 non] na .4 deus <lb/>
             eamE <hi rend="italic">misguisset A micuisset Fml</hi> 4 consortia .1 <hi rend="italic">deus id fecerit E</hi>. <lb/>
@@ -2512,7 +2512,7 @@
 <note type="footnote"> 23 </note> <lb/>
              
 <pb n="354"/>
-            culum meum cum apud te inuenisset, inrisit seque illis cautibus <lb/>
+            meum cum apud te inuenisset, inrisit seque illis cautibus <lb/>
             animosiore impetu quam consultiore commisit. sed quo cum praefidentia <lb/>
             ista perduxerit, puto quod nunc uideas; uberius autem ago <lb/>
             deo gratias, si et antea iam uidebas. cum enim nollet cohibere praecipitem <lb/>

--- a/data/stoa0040/stoa074/stoa0040.stoa074.opp-lat1.xml
+++ b/data/stoa0040/stoa074/stoa0040.stoa074.opp-lat1.xml
@@ -10824,8 +10824,8 @@
             uiginti octo, ista triginta. ideo hic non ait: ex eo quod <lb/>
             superat de uelis, sed: ex eo quod superat uelis de <lb/>
             longitudine uelorum. quid est ergo: cubitum ex hoc et <lb/>
-            cubitum ex hoc erit contegens super latera taberna <lb/>
-            culi, nisi quia illa longitudo in qua binis cubitis uela capillacia <lb n="25"/>
+            cubitum ex hoc erit contegens super latera tabernaculi <lb/>
+            , nisi quia illa longitudo in qua binis cubitis uela capillacia <lb n="25"/>
             longiora sunt aulaeis singulis singula non tota in unam
 
 <note type="footnote">7 Ex. 26, 13 </note>

--- a/data/stoa0040/stoa074/stoa0040.stoa074.opp-lat1.xml
+++ b/data/stoa0040/stoa074/stoa0040.stoa074.opp-lat1.xml
@@ -14917,7 +14917,7 @@ bd</hi> <lb/>
 </p>
           </div>
 
-<div n="" subtype="chapter" type="textpart">
+<div n="94" subtype="chapter" type="textpart">
 
 <p>Quid est quod inoboedientiae poenas cum minaretur <lb/>
             deus, dixit inter cetera: et consumet uos perambulans <lb/>

--- a/data/stoa0040a/stoa002/stoa0040a.stoa002.opp-lat1.xml
+++ b/data/stoa0040a/stoa002/stoa0040a.stoa002.opp-lat1.xml
@@ -18758,8 +18758,8 @@
 
 <div n="19" subtype="section" type="textpart">
 <p>Audi nunc, catholice, euangelio teste prodesse hominis <lb n="10"/>
-            natiuitatem. cum Symeon enim uir iustus uellet exire de sae. <lb/>
-            culo sufficere sibi putans creatoris sine mysterii eius cognitione <lb/>
+            natiuitatem. cum Symeon enim uir iustus uellet exire de saeculo <lb/>
+             sufficere sibi putans creatoris sine mysterii eius cognitione <lb/>
             notitiam, non permissum est ei, nisi crementum faceret in <lb/>
             dei perceptione, ut plenam haberet fidei suae mercedem. denique <lb/>
             natum saluatorem accipiens in manibus benedixit deum et <lb n="15"/>

--- a/data/stoa0058/stoa001/stoa0058.stoa001.opp-lat3.xml
+++ b/data/stoa0058/stoa001/stoa0058.stoa001.opp-lat3.xml
@@ -5720,8 +5720,8 @@ T2L1V2E
 <div n="1" subtype="section" type="textpart">
 <p>Ita est, inquam; sed cum tui muneris sit latentium<lb/>
             rerum causas evolvere velatasque caligine explicare rationes, <lb n="20"/>
-            quaeso, uti, quae hinc decernas, quoniam hoc me mira- <lb/>
-            culum maxime perturbat, edisseras. — Tum illa.</p></div>
+            quaeso, uti, quae hinc decernas, quoniam hoc me miraculum <lb/>
+             maxime perturbat, edisseras. — Tum illa.</p></div>
 
 <div n="2" subtype="section" type="textpart"><p>paulisper  <lb/>
             arridens: Ad rem me, inquit, omnium quaesitu maximam <lb/>

--- a/data/stoa0104p/stoa008/stoa0104p.stoa008.opp-lat1.xml
+++ b/data/stoa0104p/stoa008/stoa0104p.stoa008.opp-lat1.xml
@@ -318,7 +318,7 @@
             uiuus translatus est in loco ubi Deus scit: ex quo loco consummatione <lb/>
             mundi innouari habet in hoc mundo, unde et translatus est ad confundendum <lb/>
             et reuincendum antichristum: a quo interfecti martyria <lb/>
-            sua conplebunt, uiuentes in aeternum in saecula sae culorum. et ideo <lb/>
+            sua conplebunt, uiuentes in aeternum in saecula saeculorum. et ideo <lb/>
             Enoch interpretat \'innouatus\' deinde Iob iustus, qui ante diem iudicii <lb n="15"/>
             meruit uoce iudicis laudari, et ideo deuicto diabolo et superato <lb/>
             Iob interpretat \'carissimus Dei\\ aeque et Abraham in sua natiuitate <lb/>

--- a/data/stoa0244d/stoa005/stoa0244d.stoa005.opp-lat1.xml
+++ b/data/stoa0244d/stoa005/stoa0244d.stoa005.opp-lat1.xml
@@ -2553,8 +2553,8 @@
              <pb n="75"/>
             arma potentia et uirilia exiguo uelit corpori et puerilibus <lb/>
             membris inserere; paruis autem tutius est paruum onus et <lb/>
-            non supra uires leuare, ne uel derisui fiant, simul et peri­ <lb/>
-            culum subeant, sicut ne turrem quidem aedificare conuenit <lb/>
+            non supra uires leuare, ne uel derisui fiant, simul et peri­culum <lb/>
+             subeant, sicut ne turrem quidem aedificare conuenit <lb/>
             alii nisi ei cui inpensae quoque perficiendi praesto sunt. <lb n="5"/>
             </p>
           <p n="102">102. 103. Haec est apologia et excusatio fugae meae et hae <lb/>
@@ -3472,8 +3472,8 @@
             diaboli est et omnium qui sub eo militant. peccantes autem <lb/>
             conuerti a peccato hominum est qui credunt in deo et quo­ <lb/>
             rum pars inter eos est qui saluantur. licet enim et terra <note type="chapter">2 </note> <lb/>
-            haec inuoluat secum malitiae non parum et terrenum habita­ <lb n="20"/>
-            culum adgrauet sensum multa cogitantem et sursum aspicientem, <lb/>
+            haec inuoluat secum malitiae non parum et terrenum habita­culum <lb n="20"/>
+             adgrauet sensum multa cogitantem et sursum aspicientem, <lb/>
             immo ad hoc creatum, ut quae sursum sunt quaerat, sed <lb/>
             imago dei labem corporeae inundationis expurget et coniunc­ <lb/>
             tam sibi carnem uerbi dei subleuet pennis. et quamuis melius <note type="footnote">5 cf. Ps. 125, 5 8 cf. Gen. 19, 17. 23 11 cf. Gen. 19. 26 <lb/>

--- a/data/stoa0249a/stoa002/stoa0249a.stoa002.opp-lat1.xml
+++ b/data/stoa0249a/stoa002/stoa0249a.stoa002.opp-lat1.xml
@@ -8130,8 +8130,8 @@
             ad Africam transierunt non est diuinae seueritati sed Afrorum <lb n="5"/>
             sceleri deputandum; graui enim eos, antequam illuc pergerent, <lb/>
             ac longa iniquitate traxerunt. et ideo intellegere debemus, quia <lb/>
-            pietatis diuinae fuit, quod poenam diu debitam distulit, pia-. <lb/>
-            culorum autem et criminum, quod aliquando peccator populus <lb/>
+            pietatis diuinae fuit, quod poenam diu debitam distulit, piaculorum <lb/>
+             autem et criminum, quod aliquando peccator populus <lb/>
             quae merebatur excepit. nisi forte Afros hoc non meruisse <lb n="10"/>
             credimus, cum utique nulli magis, utpote in quos omnia simul <lb/>
             improbitatum atque impuritatum genera confluxerint.</p></div>

--- a/data/stoa0292e/stoa001/stoa0292e.stoa001.opp-lat1.xml
+++ b/data/stoa0292e/stoa001/stoa0292e.stoa001.opp-lat1.xml
@@ -1660,8 +1660,8 @@ ideoque ait: unum de animalibus, quia omnia quattuor unum<lb/>
 
 <div n="4" subtype="section" type="textpart"><p> <note type="margin"> 11, 4 </note> Hi sunt duae oliuae et duo candelabra, qui in <lb/>
             conspectu domini terrae stant, id est in paradiso. hos<lb n="5"/>
-            ergo oportet interfici ab Antichristo post multas plagas sae- <note type="margin"> 11, 7 </note> <lb/>
-            culo infixas, quem dicit ascendisse bestiam de abysso. <lb/>
+            ergo oportet interfici ab Antichristo post multas plagas saeculo <note type="margin"> 11, 7 </note> <lb/>
+             infixas, quem dicit ascendisse bestiam de abysso. <lb/>
             (de abysso) autem eum ascensurum multa testimonia nobis <lb/>
             in hoc capitulo contrahenda sunt. ait enim Esaias: ecce <lb/>
             Assur cypressus in monte Libano. «Assul\'&gt;: deprimens;<lb n="10"/>


### PR DESCRIPTION
Fixed few situation where culus would be separated from its prefix, resulting in a non expected word to be in the Christian texts.